### PR TITLE
Add gem for CircleCI deployment to S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gem 'jekyll-paginate'
 # Added at 2018-01-15 15:18:35 +0000 by root:
 gem "jekyll-pagination", "~> 0.0.4"
 
-# Added at 2018-01-30 by JohnWeaver // Allows CircleCI to upload to S3
-gem 's3_website '
+# Added at 2018-02-02 11:36:54 +0000 by kevin:
+gem "s3_website", "~> 3.4"

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gem 'jekyll-paginate'
 
 # Added at 2018-01-15 15:18:35 +0000 by root:
 gem "jekyll-pagination", "~> 0.0.4"
+
+# Added at 2018-01-30 by JohnWeaver // Allows CircleCI to upload to S3
+gem 's3_website '

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,26 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    aws-sdk (2.10.125)
+      aws-sdk-resources (= 2.10.125)
+    aws-sdk-core (2.10.125)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.10.125)
+      aws-sdk-core (= 2.10.125)
+    aws-sigv4 (1.0.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
+    colored (1.2)
     concurrent-ruby (1.0.5)
+    configure-s3-website (2.3.0)
+      aws-sdk (~> 2)
+      deep_merge (~> 1.0.0)
+    deep_merge (1.0.1)
+    dotenv (1.0.2)
     ethon (0.10.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -155,6 +169,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
+    jmespath (1.3.1)
     kramdown (1.13.2)
     liquid (3.0.6)
     listen (3.0.6)
@@ -178,6 +193,11 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rouge (1.11.1)
+    s3_website (3.4.0)
+      colored (= 1.2)
+      configure-s3-website (= 2.3.0)
+      dotenv (~> 1.0)
+      thor (~> 0.18)
     safe_yaml (1.0.4)
     sass (3.4.24)
     sawyer (0.8.1)
@@ -185,6 +205,7 @@ GEM
       faraday (~> 0.8, < 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thor (0.20.0)
     thread_safe (0.3.6)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
@@ -199,6 +220,7 @@ DEPENDENCIES
   github-pages
   jekyll-paginate
   jekyll-pagination (~> 0.0.4)
+  s3_website (~> 3.4)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
To allow CircleCI to automatically deploy the Learning Hub to an S3 bucket on AWS on Master builds.