### PR TITLE
Add excluded files for Jekyll to ignore

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,9 @@ tipue_search:
   include:
     pages: true
 gems: [jekyll-paginate]
+exclude:
+  - vendor
+  - Gemfile
+  - Gemfile.lock
+  - s3_website.yml
+  - circle.yml


### PR DESCRIPTION
Added exclude: to prevent configuration files being deployed to the production environment.