### PR TITLE
Fix missing block header `exclude_from_upload:`

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -29,6 +29,7 @@ s3_endpoint: eu-west-1
 # ignore_on_server: that_folder_of_stuff_i_dont_keep_locally
 
 # Skipping config files:
+exclude_from_upload:
   - Gemfile
   - _config.yml
   - s3_website.yml


### PR DESCRIPTION
File was missing a block header before the excluded file list