### PR TITLE
fixes position:sticky cutting off bottom of long left navs

### DIFF
--- a/_data/recents.yml
+++ b/_data/recents.yml
@@ -1,13 +1,11 @@
 - name: Recently updated 🔥
   section_id: What's new
   children:
-    - name: Guide directory page
-      path: guides/
+    - name: Frequently Asked Questions
+      path: faqs/
     - name: Getting started with Hystreet
       path: guides/getting-started-with-hystreet/
     - name: Setting up stripe
       path: guides/setting-up-stripe/
     - name: Using the staff site
       path: guides/staff-site/
-    - name: Getting support
-      path: support/

--- a/css/style.css
+++ b/css/style.css
@@ -590,6 +590,8 @@ textarea {
 .footer {
   background: #232323;
   padding: 40px 0 20px;
+  position: relative;
+  z-index: 3;
 }
 
 .footer h1 {
@@ -1306,8 +1308,14 @@ body {
   @supports (position: sticky) {
   .lh-left-nav {
     position: sticky;
-    top: 250px;
+    top: 195px;
     }
+  }
+}
+@media only screen and (max-height: 750px){
+  .lh-left-nav {
+    position: relative;
+    top: 0;
   }
 }
 


### PR DESCRIPTION
- fixes long left navs not being visible due to `position: sticky` with a media query
- copy change on 'recently added' left nav