### PR TITLE
Direct Learning Hub build to new S3 Bucket

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,4 +1,4 @@
-s3_bucket: learninghub.hystreet.co.uk
+s3_bucket: learninghub-live
 
 # Below are examples of all the available configurations.
 # See README for more detailed info on each of them.


### PR DESCRIPTION
The naming of the previous S3 bucket broke CloudFront's HTTPS connection to the S3 bucket. Put simpler name in to resolve.